### PR TITLE
Revert "Bump version"

### DIFF
--- a/fabric/version.py
+++ b/fabric/version.py
@@ -7,7 +7,7 @@ which in turn needs access to this version information.)
 """
 
 
-VERSION = (1, 19, 3, 'final', 0)
+VERSION = (1, 19, 2, 'final', 0)
 
 
 def git_sha():


### PR DESCRIPTION
Per https://github.com/ploxiln/fab-classic/pull/83#issuecomment-2723210867

We don't actually need/use the version number, we check if the package is up-to-date with main. See  https://github.com/Expensify/Ops-Configs/blob/main/saltfab/fabfile.py#L42-L93 and https://github.com/Expensify/Ops-Configs/blob/main/saltfab/requirements.txt#L1