### PR TITLE
Replace multiprocessing with threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 # emacs, vim
 *~
 .*.swp
+
+.claude/

--- a/fabric/exceptions.py
+++ b/fabric/exceptions.py
@@ -7,10 +7,8 @@ Most are simply distinct Exception subclasses for purposes of message-passing
 
 
 class NetworkError(Exception):
-    # Must allow for calling with zero args/kwargs, since pickle is apparently
-    # stupid with exceptions and tries to call it as such when passed around in
-    # a multiprocessing.Queue.
-    def __init__(self, message=None, wrapped=None):
+    # Must allow for calling with zero args/kwargs for consistency.
+    def __init__(self, message, wrapped):
         self.message = message
         self.wrapped = wrapped
 

--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -1,19 +1,14 @@
 """
 Sliding-window-based job/task queue class (& example of use.)
 
-May use ``multiprocessing.Process`` or ``threading.Thread`` objects as queue
-items, though within Fabric itself only ``Process`` objects are used/supported.
+Uses ``threading.Thread`` objects as queue items for parallel task execution.
 """
 
 import time
 import queue as Queue
-from collections import namedtuple
 
 from fabric.network import ssh
 from fabric.context_managers import settings
-
-
-DoneProc = namedtuple('DoneProc', ['name', 'exitcode'])
 
 class JobQueue(object):
     """
@@ -147,14 +142,6 @@ class JobQueue(object):
                         if self._debug:
                             print("Job queue found finished proc: %s." % job.name)
                         done = self._running.pop(id)
-                        # might be a Process or a Thread
-                        if hasattr(done, 'exitcode'):
-                            proc = done
-                            done = DoneProc(proc.name, proc.exitcode)
-                            # multiprocessing.Process.close() added in Python-3.7
-                            if hasattr(proc, 'close'):
-                                proc.close()
-                            del proc
                         self._completed.append(done)
 
                 if self._debug:
@@ -178,33 +165,35 @@ class JobQueue(object):
         # already have finished.
         self._fill_results(results)
 
-        # Attach exit codes now that we're all done & have joined all jobs
-        for job in self._completed:
-            if hasattr(job, 'exitcode'):
-                results[job.name]['exit_code'] = job.exitcode
-
         return results
 
     def _fill_results(self, results):
         """
         Attempt to pull data off self._comms_queue and add to 'results' dict.
         If no data is available (i.e. the queue is empty), bail immediately.
+
+        Exit codes are derived from the result type: exceptions map to 1,
+        normal results map to 0.
         """
         while True:
             try:
                 datum = self._comms_queue.get_nowait()
                 results[datum['name']]['results'] = datum['result']
+                if isinstance(datum['result'], BaseException):
+                    results[datum['name']]['exit_code'] = 1
+                else:
+                    results[datum['name']]['exit_code'] = 0
             except Queue.Empty:
                 break
 
 
 # Sample
-
-def try_using(parallel_type):
+def sample_usage():
     """
-    This will run the queue through it's paces, and show a simple way of using
-    the job queue.
+    This will run the queue through its paces, and show a simple way of using
+    the job queue with threads.
     """
+    from threading import Thread
 
     def print_number(number):
         """
@@ -212,30 +201,23 @@ def try_using(parallel_type):
         """
         print(number)
 
-    if parallel_type == "multiprocessing":
-        from multiprocessing import Process as Bucket
-
-    elif parallel_type == "threading":
-        from threading import Thread as Bucket
-
     # Make a job_queue with a bubble of len 5, and have it print verbosely
     queue = Queue.Queue()
     jobs = JobQueue(5, queue)
     jobs._debug = True
 
-    # Add 20 procs onto the stack
+    # Add 20 threads onto the stack
     for x in range(20):
-        jobs.append(Bucket(
+        jobs.append(Thread(
             target=print_number,
             args=[x],
             kwargs={},
         ))
 
-    # Close up the queue and then start it's execution
+    # Close up the queue and then start its execution
     jobs.close()
     jobs.run()
 
 
 if __name__ == '__main__':
-    try_using("multiprocessing")
-    try_using("threading")
+    sample_usage()

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -6,6 +6,7 @@ from functools import wraps
 import getpass
 import os
 import re
+import threading
 import time
 import socket
 import sys
@@ -161,6 +162,102 @@ class HostConnectionCache(dict):
 
     def __contains__(self, key):
         return dict.__contains__(self, normalize_to_string(key))
+
+
+class _ThreadLocalHostConnectionCache(HostConnectionCache):
+    """
+    ``HostConnectionCache`` subclass with thread-local override support.
+
+    Worker threads call ``_set_thread_local()`` to get their own empty
+    connection cache so SSH connections are not shared across threads.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        dict.__setattr__(self, '_tl', threading.local())
+
+    def _set_thread_local(self):
+        """Install an empty per-thread ``HostConnectionCache``."""
+        self._tl._data = HostConnectionCache()
+
+    def _clear_thread_local(self):
+        """Remove the per-thread cache."""
+        try:
+            del self._tl._data
+        except AttributeError:
+            pass
+
+    def _local(self):
+        return getattr(self._tl, '_data', None)
+
+    def __getitem__(self, key):
+        local = self._local()
+        if local is not None:
+            return local[key]
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        local = self._local()
+        if local is not None:
+            local[key] = value
+            return
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        local = self._local()
+        if local is not None:
+            del local[key]
+            return
+        super().__delitem__(key)
+
+    def __contains__(self, key):
+        local = self._local()
+        if local is not None:
+            return key in local
+        return super().__contains__(key)
+
+    def clear(self):
+        local = self._local()
+        if local is not None:
+            local.clear()
+            return
+        super().clear()
+
+    def keys(self):
+        local = self._local()
+        if local is not None:
+            return local.keys()
+        return super().keys()
+
+    def values(self):
+        local = self._local()
+        if local is not None:
+            return local.values()
+        return super().values()
+
+    def items(self):
+        local = self._local()
+        if local is not None:
+            return local.items()
+        return super().items()
+
+    def __iter__(self):
+        local = self._local()
+        if local is not None:
+            return iter(local)
+        return super().__iter__()
+
+    def __len__(self):
+        local = self._local()
+        if local is not None:
+            return len(local)
+        return super().__len__()
+
+    def __repr__(self):
+        local = self._local()
+        if local is not None:
+            return repr(local)
+        return super().__repr__()
 
 
 def ssh_config(host_string=None):

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -6,7 +6,6 @@ from functools import wraps
 import getpass
 import os
 import re
-import threading
 import time
 import socket
 import sys
@@ -15,7 +14,7 @@ from io import StringIO
 import paramiko as ssh
 
 from fabric.auth import get_password, set_password
-from fabric.utils import handle_prompt_abort, warn
+from fabric.utils import _ThreadLocalDictMixin, handle_prompt_abort, warn
 from fabric.exceptions import NetworkError
 
 
@@ -164,100 +163,17 @@ class HostConnectionCache(dict):
         return dict.__contains__(self, normalize_to_string(key))
 
 
-class _ThreadLocalHostConnectionCache(HostConnectionCache):
+class _ThreadLocalHostConnectionCache(_ThreadLocalDictMixin, HostConnectionCache):
     """
-    ``HostConnectionCache`` subclass with thread-local override support.
+    ``HostConnectionCache`` with thread-local override support.
 
     Worker threads call ``_set_thread_local()`` to get their own empty
     connection cache so SSH connections are not shared across threads.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        dict.__setattr__(self, '_tl', threading.local())
-
     def _set_thread_local(self):
         """Install an empty per-thread ``HostConnectionCache``."""
-        self._tl._data = HostConnectionCache()
-
-    def _clear_thread_local(self):
-        """Remove the per-thread cache."""
-        try:
-            del self._tl._data
-        except AttributeError:
-            pass
-
-    def _local(self):
-        return getattr(self._tl, '_data', None)
-
-    def __getitem__(self, key):
-        local = self._local()
-        if local is not None:
-            return local[key]
-        return super().__getitem__(key)
-
-    def __setitem__(self, key, value):
-        local = self._local()
-        if local is not None:
-            local[key] = value
-            return
-        super().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        local = self._local()
-        if local is not None:
-            del local[key]
-            return
-        super().__delitem__(key)
-
-    def __contains__(self, key):
-        local = self._local()
-        if local is not None:
-            return key in local
-        return super().__contains__(key)
-
-    def clear(self):
-        local = self._local()
-        if local is not None:
-            local.clear()
-            return
-        super().clear()
-
-    def keys(self):
-        local = self._local()
-        if local is not None:
-            return local.keys()
-        return super().keys()
-
-    def values(self):
-        local = self._local()
-        if local is not None:
-            return local.values()
-        return super().values()
-
-    def items(self):
-        local = self._local()
-        if local is not None:
-            return local.items()
-        return super().items()
-
-    def __iter__(self):
-        local = self._local()
-        if local is not None:
-            return iter(local)
-        return super().__iter__()
-
-    def __len__(self):
-        local = self._local()
-        if local is not None:
-            return len(local)
-        return super().__len__()
-
-    def __repr__(self):
-        local = self._local()
-        if local is not None:
-            return repr(local)
-        return super().__repr__()
+        self._thread_local._data = HostConnectionCache()
 
 
 def ssh_config(host_string=None):

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -8,9 +8,9 @@ from optparse import make_option
 
 import paramiko as ssh
 
-from fabric.network import HostConnectionCache
+from fabric.network import HostConnectionCache, _ThreadLocalHostConnectionCache
 from fabric.version import get_version
-from fabric.utils import _AliasDict, _AttributeDict
+from fabric.utils import _AliasDict, _AttributeDict, _ThreadLocalAttributeDict
 
 
 #
@@ -351,7 +351,7 @@ env_options = [
 # Most default values are specified in `env_options` above, in the interests of
 # preserving DRY: anything in here is generally not settable via the command
 # line.
-env = _AttributeDict({
+env = _ThreadLocalAttributeDict({
     'abort_exception': None,
     'again_prompt': 'Sorry, try again.',
     'all_hosts': [],
@@ -429,7 +429,7 @@ commands = {}
 # Host connection dict/cache
 #
 
-connections = HostConnectionCache()
+connections = _ThreadLocalHostConnectionCache()
 
 
 def _open_session():

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -234,7 +234,7 @@ def _execute(task, host, my_env, args, kwargs, jobs, task_queue):
             'task': task,
             'args': args,
             'kwargs': kwargs,
-            'queue': task_queue,
+            'task_queue': task_queue,
             'name': name,
             'env': local_env,
         }

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,6 +1,8 @@
 import inspect
+import queue
 import sys
 import textwrap
+import threading
 
 from fabric import state
 from fabric.utils import abort, warn, error
@@ -182,17 +184,16 @@ def _is_network_error_ignored():
     return not state.env.use_exceptions_for['network'] and state.env.skip_bad_hosts
 
 
-def _parallel_wrap(task, args, kwargs, queue, name, env):
+def _parallel_wrap(task, args, kwargs, task_queue, name, env):
     # Wrap in another callable that:
-    # * expands the env it's given to ensure parallel, linewise, etc are
-    #   all set correctly and explicitly
-    # * nukes the connection cache to prevent shared-access problems
+    # * installs a thread-local copy of env for isolation
+    # * gives this thread its own connection cache
     # * knows how to send the tasks' return value back over a Queue
     # * captures exceptions raised by the task
-    state.env.update(env)
+    state.env._set_thread_local(env)
+    state.connections._set_thread_local()
     try:
-        state.connections.clear()
-        queue.put({'name': name, 'result': task.run(*args, **kwargs)})
+        task_queue.put({'name': name, 'result': task.run(*args, **kwargs)})
     except BaseException as e:  # We really do want to capture everything
         # SystemExit implies use of abort(), which prints its own
         # traceback, host info etc -- so we don't want to double up
@@ -202,14 +203,16 @@ def _parallel_wrap(task, args, kwargs, queue, name, env):
         if type(e) is not SystemExit:
             if not (isinstance(e, NetworkError) and _is_network_error_ignored()):
                 sys.stderr.write("!!! Parallel execution exception under host %r:\n" % name)
-            queue.put({'name': name, 'result': e})
-        # Here, anything -- unexpected exceptions, or abort()
-        # driven SystemExits -- will bubble up and terminate the
-        # child process.
-        if not (isinstance(e, NetworkError) and _is_network_error_ignored()):
-            raise
+        task_queue.put({'name': name, 'result': e})
+        # NOTE: We intentionally do NOT re-raise here. With threads (unlike
+        # processes), re-raising would trigger threading.excepthook and
+        # duplicate the traceback on stderr.
+    finally:
+        disconnect_all()
+        state.connections._clear_thread_local()
+        state.env._clear_thread_local()
 
-def _execute(task, host, my_env, args, kwargs, jobs, queue, multiprocessing):
+def _execute(task, host, my_env, args, kwargs, jobs, task_queue):
     """
     Primary single-host work body of execute()
     """
@@ -220,22 +223,23 @@ def _execute(task, host, my_env, args, kwargs, jobs, queue, multiprocessing):
     local_env = to_dict(host)
     local_env.update(my_env)
     # Set a few more env flags for parallelism
-    if queue is not None:
+    if task_queue is not None:
         local_env.update({'parallel': True, 'linewise': True})
     # Handle parallel execution
-    if queue is not None: # Since queue is only set for parallel
+    if task_queue is not None: # Since queue is only set for parallel
         name = local_env['host_string']
 
-        # Stuff into Process wrapper
+        # Stuff into Thread wrapper
         kwarg_dict = {
             'task': task,
             'args': args,
             'kwargs': kwargs,
-            'queue': queue,
+            'queue': task_queue,
             'name': name,
             'env': local_env,
         }
-        p = multiprocessing.Process(target=_parallel_wrap, kwargs=kwarg_dict)
+        p = threading.Thread(target=_parallel_wrap, kwargs=kwarg_dict)
+        p.daemon = True
         # Name/id is host string
         p.name = name
         # Add to queue
@@ -324,17 +328,13 @@ def execute(task, *args, **kwargs):
 
     parallel = requires_parallel(task)
     if parallel:
-        import multiprocessing
-        ctx = multiprocessing.get_context('fork')
-        # Set up job queue for parallel cases
-        queue = ctx.Queue()
+        task_queue = queue.Queue()
     else:
-        ctx = None
-        queue = None
+        task_queue = None
 
     # Get pool size for this task
     pool_size = task.get_pool_size(my_env['all_hosts'], state.env.pool_size)
-    jobs = JobQueue(pool_size, queue)
+    jobs = JobQueue(pool_size, task_queue)
     if state.output.debug:
         jobs._debug = True
 
@@ -344,7 +344,7 @@ def execute(task, *args, **kwargs):
         for host in my_env['all_hosts']:
             try:
                 results[host] = _execute(
-                    task, host, my_env, args, new_kwargs, jobs, queue, ctx,
+                    task, host, my_env, args, new_kwargs, jobs, task_queue,
                 )
             except NetworkError as e:
                 results[host] = e

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -6,6 +6,7 @@ import os
 import sys
 import struct
 import textwrap
+import threading
 from traceback import format_exc
 
 
@@ -268,6 +269,185 @@ class _AliasDict(_AttributeDict):
             else:
                 ret.append(key)
         return ret
+
+
+class _ThreadLocalAttributeDict(_AttributeDict):
+    """
+    ``_AttributeDict`` subclass with thread-local override support.
+
+    In the main thread (or any thread that hasn't called ``_set_thread_local``),
+    this behaves exactly like a normal ``_AttributeDict``.
+
+    Worker threads call ``_set_thread_local(data)`` to install a per-thread
+    copy.  All dict/attribute operations then delegate to that copy, isolating
+    each thread's mutations from the shared base dict.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Use dict.__setattr__ to avoid triggering _AttributeDict's __setattr__
+        # which would create a key in the dict.
+        dict.__setattr__(self, '_tl', threading.local())
+
+    # -- thread-local management ------------------------------------------
+
+    def _set_thread_local(self, data):
+        """Install a per-thread ``_AttributeDict`` copy.
+
+        Starts from a snapshot of the shared base dict, then applies
+        *data* as overrides so the thread gets a complete env.
+        """
+        local = _AttributeDict(dict.copy(self))
+        local.update(data)
+        self._tl._data = local
+
+    def _clear_thread_local(self):
+        """Remove the per-thread copy, reverting to the shared base dict."""
+        try:
+            del self._tl._data
+        except AttributeError:
+            pass
+
+    def _local(self):
+        """Return the thread-local dict if set, else ``None``."""
+        return getattr(self._tl, '_data', None)
+
+    # -- dict overrides ----------------------------------------------------
+
+    def __getitem__(self, key):
+        local = self._local()
+        if local is not None:
+            return local[key]
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        local = self._local()
+        if local is not None:
+            local[key] = value
+            return
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        local = self._local()
+        if local is not None:
+            del local[key]
+            return
+        super().__delitem__(key)
+
+    def __contains__(self, key):
+        local = self._local()
+        if local is not None:
+            return key in local
+        return super().__contains__(key)
+
+    def __iter__(self):
+        local = self._local()
+        if local is not None:
+            return iter(local)
+        return super().__iter__()
+
+    def __len__(self):
+        local = self._local()
+        if local is not None:
+            return len(local)
+        return super().__len__()
+
+    def get(self, key, *args):
+        local = self._local()
+        if local is not None:
+            return local.get(key, *args)
+        return super().get(key, *args)
+
+    def update(self, *args, **kwargs):
+        local = self._local()
+        if local is not None:
+            local.update(*args, **kwargs)
+            return
+        super().update(*args, **kwargs)
+
+    def pop(self, *args):
+        local = self._local()
+        if local is not None:
+            return local.pop(*args)
+        return super().pop(*args)
+
+    def setdefault(self, key, *args):
+        local = self._local()
+        if local is not None:
+            return local.setdefault(key, *args)
+        return super().setdefault(key, *args)
+
+    def keys(self):
+        local = self._local()
+        if local is not None:
+            return local.keys()
+        return super().keys()
+
+    def values(self):
+        local = self._local()
+        if local is not None:
+            return local.values()
+        return super().values()
+
+    def items(self):
+        local = self._local()
+        if local is not None:
+            return local.items()
+        return super().items()
+
+    def clear(self):
+        local = self._local()
+        if local is not None:
+            local.clear()
+            return
+        super().clear()
+
+    def copy(self):
+        local = self._local()
+        if local is not None:
+            return local.copy()
+        return super().copy()
+
+    def __repr__(self):
+        local = self._local()
+        if local is not None:
+            return repr(local)
+        return super().__repr__()
+
+    # -- _AttributeDict overrides ------------------------------------------
+
+    def __getattr__(self, key):
+        # _tl is stored via dict.__setattr__, so normal attribute access won't
+        # find it through __getitem__.  Avoid infinite recursion.
+        if key == '_tl':
+            raise AttributeError(key)
+        local = self._local()
+        if local is not None:
+            try:
+                return local[key]
+            except KeyError:
+                raise AttributeError(key)
+        return super().__getattr__(key)
+
+    def __setattr__(self, key, value):
+        if key == '_tl':
+            dict.__setattr__(self, key, value)
+            return
+        local = self._local()
+        if local is not None:
+            local[key] = value
+            return
+        super().__setattr__(key, value)
+
+    def first(self, *names):
+        local = self._local()
+        if local is not None:
+            for name in names:
+                value = local.get(name)
+                if value:
+                    return value
+            return None
+        return super().first(*names)
 
 
 def _pty_size():

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -271,25 +271,82 @@ class _AliasDict(_AttributeDict):
         return ret
 
 
-class _ThreadLocalAttributeDict(_AttributeDict):
+def _make_thread_local_delegator(name, parent_class):
+    """Create a method that delegates to a thread-local copy if present."""
+    parent_method = getattr(parent_class, name)
+    def method(self, *args, **kwargs):
+        local = self._local()
+        if local is not None:
+            return getattr(local, name)(*args, **kwargs)
+        return parent_method(self, *args, **kwargs)
+    method.__name__ = name
+    return method
+
+
+class _ThreadLocalDictMixin:
     """
-    ``_AttributeDict`` subclass with thread-local override support.
+    Mixin that adds thread-local isolation to dict-like classes.
 
     In the main thread (or any thread that hasn't called ``_set_thread_local``),
-    this behaves exactly like a normal ``_AttributeDict``.
+    this behaves exactly like the base class.  Worker threads get an isolated
+    per-thread copy that all dict operations delegate to.
 
-    Worker threads call ``_set_thread_local(data)`` to install a per-thread
-    copy.  All dict/attribute operations then delegate to that copy, isolating
-    each thread's mutations from the shared base dict.
+    Subclasses can extend ``_thread_local_methods`` to auto-delegate additional methods,
+    and can still override methods manually when special handling is needed.
     """
+
+    _thread_local_methods = (
+        '__getitem__', '__setitem__', '__delitem__', '__contains__',
+        '__iter__', '__len__', '__repr__',
+        'get', 'update', 'pop', 'setdefault',
+        'keys', 'values', 'items', 'clear', 'copy',
+    )
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # Find the first dict-based parent that isn't this mixin
+        parent = None
+        for base in cls.__mro__[1:]:
+            if base is _ThreadLocalDictMixin or base is object:
+                continue
+            if issubclass(base, dict):
+                parent = base
+                break
+        if parent is None:
+            return
+        for name in cls._thread_local_methods:
+            if name not in cls.__dict__:  # don't clobber explicit overrides
+                setattr(cls, name, _make_thread_local_delegator(name, parent))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Use dict.__setattr__ to avoid triggering _AttributeDict's __setattr__
-        # which would create a key in the dict.
-        dict.__setattr__(self, '_tl', threading.local())
+        dict.__setattr__(self, '_thread_local', threading.local())
 
-    # -- thread-local management ------------------------------------------
+    def _local(self):
+        """Return the thread-local data if set, else ``None``."""
+        return getattr(self._thread_local, '_data', None)
+
+    def _clear_thread_local(self):
+        """Remove the per-thread copy."""
+        try:
+            del self._thread_local._data
+        except AttributeError:
+            pass
+
+    def __copy__(self):
+        return type(self)(dict.copy(self))
+
+    def __deepcopy__(self, memo):
+        import copy
+        new = type(self)(copy.deepcopy(dict(self), memo))
+        memo[id(self)] = new
+        return new
+
+
+class _ThreadLocalAttributeDict(_ThreadLocalDictMixin, _AttributeDict):
+    """``_AttributeDict`` with thread-local override support."""
+
+    _thread_local_methods = _ThreadLocalDictMixin._thread_local_methods + ('first',)
 
     def _set_thread_local(self, data):
         """Install a per-thread ``_AttributeDict`` copy.
@@ -299,127 +356,10 @@ class _ThreadLocalAttributeDict(_AttributeDict):
         """
         local = _AttributeDict(dict.copy(self))
         local.update(data)
-        self._tl._data = local
-
-    def _clear_thread_local(self):
-        """Remove the per-thread copy, reverting to the shared base dict."""
-        try:
-            del self._tl._data
-        except AttributeError:
-            pass
-
-    def _local(self):
-        """Return the thread-local dict if set, else ``None``."""
-        return getattr(self._tl, '_data', None)
-
-    # -- dict overrides ----------------------------------------------------
-
-    def __getitem__(self, key):
-        local = self._local()
-        if local is not None:
-            return local[key]
-        return super().__getitem__(key)
-
-    def __setitem__(self, key, value):
-        local = self._local()
-        if local is not None:
-            local[key] = value
-            return
-        super().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        local = self._local()
-        if local is not None:
-            del local[key]
-            return
-        super().__delitem__(key)
-
-    def __contains__(self, key):
-        local = self._local()
-        if local is not None:
-            return key in local
-        return super().__contains__(key)
-
-    def __iter__(self):
-        local = self._local()
-        if local is not None:
-            return iter(local)
-        return super().__iter__()
-
-    def __len__(self):
-        local = self._local()
-        if local is not None:
-            return len(local)
-        return super().__len__()
-
-    def get(self, key, *args):
-        local = self._local()
-        if local is not None:
-            return local.get(key, *args)
-        return super().get(key, *args)
-
-    def update(self, *args, **kwargs):
-        local = self._local()
-        if local is not None:
-            local.update(*args, **kwargs)
-            return
-        super().update(*args, **kwargs)
-
-    def pop(self, *args):
-        local = self._local()
-        if local is not None:
-            return local.pop(*args)
-        return super().pop(*args)
-
-    def setdefault(self, key, *args):
-        local = self._local()
-        if local is not None:
-            return local.setdefault(key, *args)
-        return super().setdefault(key, *args)
-
-    def keys(self):
-        local = self._local()
-        if local is not None:
-            return local.keys()
-        return super().keys()
-
-    def values(self):
-        local = self._local()
-        if local is not None:
-            return local.values()
-        return super().values()
-
-    def items(self):
-        local = self._local()
-        if local is not None:
-            return local.items()
-        return super().items()
-
-    def clear(self):
-        local = self._local()
-        if local is not None:
-            local.clear()
-            return
-        super().clear()
-
-    def copy(self):
-        local = self._local()
-        if local is not None:
-            return local.copy()
-        return super().copy()
-
-    def __repr__(self):
-        local = self._local()
-        if local is not None:
-            return repr(local)
-        return super().__repr__()
-
-    # -- _AttributeDict overrides ------------------------------------------
+        self._thread_local._data = local
 
     def __getattr__(self, key):
-        # _tl is stored via dict.__setattr__, so normal attribute access won't
-        # find it through __getitem__.  Avoid infinite recursion.
-        if key == '_tl':
+        if key == '_thread_local':
             raise AttributeError(key)
         local = self._local()
         if local is not None:
@@ -430,7 +370,7 @@ class _ThreadLocalAttributeDict(_AttributeDict):
         return super().__getattr__(key)
 
     def __setattr__(self, key, value):
-        if key == '_tl':
+        if key == '_thread_local':
             dict.__setattr__(self, key, value)
             return
         local = self._local()
@@ -438,16 +378,6 @@ class _ThreadLocalAttributeDict(_AttributeDict):
             local[key] = value
             return
         super().__setattr__(key, value)
-
-    def first(self, *names):
-        local = self._local()
-        if local is not None:
-            for name in names:
-                value = local.get(name)
-                if value:
-                    return value
-            return None
-        return super().first(*names)
 
 
 def _pty_size():


### PR DESCRIPTION
## Problem
On `macOS()` calling `fork()` after `exec()` can cause seg faults in system libraries because they are not thread safe. This causes segfaults because the memory locations copied from the parent into the child process via `fork()` are no longer valid.

One suggested fix is to use `spawn()` instead of `fork()` but that only works if _all_ code can be pickled, which isn't always the case. The other option, which is implemented here, is to use `threading` instead.

Note, I implemented thread local versions of the `env` and other shared variables to replicate the current behavior. I know we internally have some desire to be able to share globals across execution threads for parallel tasks, but I didn't want to scope creep that into this PR, so we can address it later with a more thought out design.

This should also have some added benefits when run on ft python.

Fixes https://github.com/Expensify/Expensify/issues/601176
Fixes https://github.com/Expensify/Expensify/issues/591584