### PR TITLE
Fix logging in parallel tasks after threading change

### DIFF
--- a/fabric/thread_handling.py
+++ b/fabric/thread_handling.py
@@ -34,6 +34,7 @@ class ThreadHandler(object):
             finally:
                 if parent_env is not None:
                     env._clear_thread_local()
+
         # Kick off thread
         thread = threading.Thread(None, wrapper, name, args, kwargs)
         thread.setDaemon(True)

--- a/fabric/thread_handling.py
+++ b/fabric/thread_handling.py
@@ -1,6 +1,8 @@
 import threading
 import sys
 
+from fabric.state import env
+
 
 def reraise(tp, value, tb=None):
     try:
@@ -19,11 +21,19 @@ class ThreadHandler(object):
         # Set up exception handling
         self.exception = None
 
+        # Capture the parent thread's env so child threads inherit it
+        parent_env = env._local()
+
         def wrapper(*args, **kwargs):
             try:
+                if parent_env is not None:
+                    env._thread_local._data = parent_env
                 callable(*args, **kwargs)
             except BaseException:
                 self.exception = sys.exc_info()
+            finally:
+                if parent_env is not None:
+                    env._clear_thread_local()
         # Kick off thread
         thread = threading.Thread(None, wrapper, name, args, kwargs)
         thread.setDaemon(True)


### PR DESCRIPTION
@rafecolton Please review. A small bug from the threading change I noticed this morning:

```
pgab -H "bastion*" -- 'ls'
[INFO] Matched hosts: ["bastion1.lax", "bastion1.rno", "bastion1.sjc"]
[bastion1.lax] Executing task '<remainder>'
[bastion1.rno] Executing task '<remainder>'
[bastion1.sjc] Executing task '<remainder>'
[bastion1.sjc] run: ls
[bastion1.rno] run: ls
[bastion1.lax] run: ls
[None] out: REDACTED
[None] out: REDACTED
[None] out:

Disconnecting from bastion1.sjc ... done.
[None] out: REDACTED
[None] out:

Disconnecting from bastion1.sjc ... done.
Disconnecting from bastion1.rno ... done.
[None] out: REDACTED
[None] out:

Disconnecting from bastion1.sjc ... done.
Disconnecting from bastion1.lax ... done.

Done.
```
The output from each task is missing the host string.

Fix by passing a thread local copy of the env into the sub thread that runs the task from the parent thread that runs each host connection:

```
uv run saltfab -P -H 'bastion*' -- 'ls'
[INFO] Matched hosts: ["bastion1.lax", "bastion1.rno", "bastion1.sjc"]
[bastion1.lax] Executing task '<remainder>'
[bastion1.rno] Executing task '<remainder>'
[bastion1.sjc] Executing task '<remainder>'
[bastion1.sjc] run: ls
[bastion1.rno] run: ls
[bastion1.lax] run: ls
[bastion1.lax] out: REDACTED
[bastion1.lax] out:

Disconnecting from bastion1.lax ... done.
[bastion1.rno] out: REDACTED
[bastion1.rno] out:

Disconnecting from bastion1.rno ... done.
[bastion1.sjc] out: REDACTED
[bastion1.sjc] out: REDACTED
[bastion1.sjc] out:

Disconnecting from bastion1.sjc ... done.

Done.
```
