### PR TITLE
Fix terminal corruption from threaded parallel tasks

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -40,13 +40,6 @@ if not win32:
     import termios
     import tty
 
-# Lock and refcount to protect terminal attribute changes from concurrent threads.
-# Only the first thread to enter char_buffered saves/sets terminal attrs;
-# only the last thread to leave restores them.
-_char_buffered_lock = threading.Lock()
-_char_buffered_refcount = 0
-_char_buffered_old_settings = None
-
 
 def _set_output(groups, which):
     """
@@ -414,33 +407,42 @@ def prefix(command):
     return _setenv(lambda: {'command_prefixes': state.env.command_prefixes + [command]})
 
 
-@documented_contextmanager
-def char_buffered(pipe):
+class _CharBufferedManager:
     """
-    Force local terminal ``pipe`` be character, not line, buffered.
+    Thread-safe manager for character-buffered terminal mode.
 
-    Only applies on Unix-based systems; on Windows this is a no-op.
-
-    Thread-safe: when multiple threads enter concurrently, terminal attributes
-    are saved once on first entry and restored once on last exit.
+    Tracks per-pipe refcounts so that the first thread to enter saves the
+    original terminal attributes and sets cbreak mode, and the last thread
+    to exit restores them.
     """
-    global _char_buffered_refcount, _char_buffered_old_settings
-    if win32 or not isatty(pipe):
-        yield
-    else:
-        with _char_buffered_lock:
-            _char_buffered_refcount += 1
-            if _char_buffered_refcount == 1:
-                _char_buffered_old_settings = termios.tcgetattr(pipe)
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._refcounts = {}
+        self._old_settings = {}
+
+    @contextmanager
+    def __call__(self, pipe):
+        if win32 or not isatty(pipe):
+            yield
+            return
+        fd = pipe.fileno()
+        with self._lock:
+            self._refcounts[fd] = self._refcounts.get(fd, 0) + 1
+            if self._refcounts[fd] == 1:
+                self._old_settings[fd] = termios.tcgetattr(pipe)
                 tty.setcbreak(pipe)
         try:
             yield
         finally:
-            with _char_buffered_lock:
-                _char_buffered_refcount -= 1
-                if _char_buffered_refcount == 0:
-                    termios.tcsetattr(pipe, termios.TCSADRAIN, _char_buffered_old_settings)
-                    _char_buffered_old_settings = None
+            with self._lock:
+                self._refcounts[fd] -= 1
+                if self._refcounts[fd] == 0:
+                    termios.tcsetattr(pipe, termios.TCSADRAIN, self._old_settings.pop(fd))
+                    del self._refcounts[fd]
+
+
+char_buffered = _CharBufferedManager()
 
 
 def shell_env(**kw):

--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -21,6 +21,7 @@ Context managers for use with the ``with`` statement.
 from contextlib import contextmanager, ExitStack
 import socket
 import select
+import threading
 
 from fabric.thread_handling import ThreadHandler
 from fabric.state import output, win32, connections, env
@@ -38,6 +39,13 @@ class nested(ExitStack):
 if not win32:
     import termios
     import tty
+
+# Lock and refcount to protect terminal attribute changes from concurrent threads.
+# Only the first thread to enter char_buffered saves/sets terminal attrs;
+# only the last thread to leave restores them.
+_char_buffered_lock = threading.Lock()
+_char_buffered_refcount = 0
+_char_buffered_old_settings = None
 
 
 def _set_output(groups, which):
@@ -412,16 +420,27 @@ def char_buffered(pipe):
     Force local terminal ``pipe`` be character, not line, buffered.
 
     Only applies on Unix-based systems; on Windows this is a no-op.
+
+    Thread-safe: when multiple threads enter concurrently, terminal attributes
+    are saved once on first entry and restored once on last exit.
     """
+    global _char_buffered_refcount, _char_buffered_old_settings
     if win32 or not isatty(pipe):
         yield
     else:
-        old_settings = termios.tcgetattr(pipe)
-        tty.setcbreak(pipe)
+        with _char_buffered_lock:
+            _char_buffered_refcount += 1
+            if _char_buffered_refcount == 1:
+                _char_buffered_old_settings = termios.tcgetattr(pipe)
+                tty.setcbreak(pipe)
         try:
             yield
         finally:
-            termios.tcsetattr(pipe, termios.TCSADRAIN, old_settings)
+            with _char_buffered_lock:
+                _char_buffered_refcount -= 1
+                if _char_buffered_refcount == 0:
+                    termios.tcsetattr(pipe, termios.TCSADRAIN, _char_buffered_old_settings)
+                    _char_buffered_old_settings = None
 
 
 def shell_env(**kw):

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -1,12 +1,16 @@
 import os
+import pty
 import sys
+import termios
+import threading
 from io import StringIO
 
 from nose.tools import eq_, ok_
 
 from fabric.state import env, output
 from fabric.context_managers import (cd, settings, lcd, hide, shell_env, quiet,
-    warn_only, prefix, path)
+    warn_only, prefix, path, char_buffered)
+import fabric.context_managers as cm
 from fabric.operations import run, local, _prefix_commands
 from mock_streams import mock_streams
 from utils import FabricTest
@@ -316,3 +320,112 @@ class TestPathManager(FabricTest):
         """
         with path('foo'):
             eq_(self.via_local(), self.real + ":foo")
+
+
+#
+# char_buffered() thread safety
+#
+
+def _open_pty():
+    """Open a pseudo-terminal and return the slave file object."""
+    master_fd, slave_fd = pty.openpty()
+    slave = os.fdopen(slave_fd, 'r')
+    return master_fd, slave
+
+
+# cbreak disables ICANON and ECHO in lflag (index 3). We check these specific
+# flags rather than comparing the full termios struct, because the pty driver
+# on macOS may toggle kernel-internal flags on tcsetattr round-trips.
+_CBREAK_LFLAG_MASK = termios.ICANON | termios.ECHO
+
+
+def _get_lflag(pipe):
+    return termios.tcgetattr(pipe)[3]
+
+
+def test_char_buffered_restores_terminal_settings():
+    """
+    char_buffered() should restore ICANON and ECHO lflag bits on exit.
+    """
+    master_fd, slave = _open_pty()
+    try:
+        original_lflag = _get_lflag(slave)
+        ok_(original_lflag & _CBREAK_LFLAG_MASK, "pty should start with ICANON|ECHO set")
+        with char_buffered(slave):
+            inside_lflag = _get_lflag(slave)
+            eq_(inside_lflag & _CBREAK_LFLAG_MASK, 0, "cbreak should clear ICANON|ECHO")
+        restored_lflag = _get_lflag(slave)
+        eq_(restored_lflag & _CBREAK_LFLAG_MASK, original_lflag & _CBREAK_LFLAG_MASK)
+    finally:
+        slave.close()
+        os.close(master_fd)
+
+
+def test_char_buffered_concurrent_threads_restore_settings():
+    """
+    When multiple threads use char_buffered() concurrently on the same pipe,
+    ICANON and ECHO should be restored after all threads exit.
+    """
+    master_fd, slave = _open_pty()
+    try:
+        original_lflag = _get_lflag(slave)
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def worker():
+            try:
+                with char_buffered(slave):
+                    barrier.wait(timeout=5)
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        eq_(errors, [])
+        restored_lflag = _get_lflag(slave)
+        eq_(restored_lflag & _CBREAK_LFLAG_MASK, original_lflag & _CBREAK_LFLAG_MASK)
+    finally:
+        slave.close()
+        os.close(master_fd)
+
+
+def test_char_buffered_refcount_returns_to_zero():
+    """
+    After all char_buffered() contexts exit, the internal refcount should be 0.
+    """
+    master_fd, slave = _open_pty()
+    try:
+        with char_buffered(slave):
+            with char_buffered(slave):
+                eq_(cm._char_buffered_refcount, 2)
+            eq_(cm._char_buffered_refcount, 1)
+        eq_(cm._char_buffered_refcount, 0)
+        ok_(cm._char_buffered_old_settings is None)
+    finally:
+        slave.close()
+        os.close(master_fd)
+
+
+def test_char_buffered_exception_still_restores():
+    """
+    char_buffered() should restore terminal settings even if an exception is raised.
+    """
+    master_fd, slave = _open_pty()
+    try:
+        original_lflag = _get_lflag(slave)
+        try:
+            with char_buffered(slave):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        restored_lflag = _get_lflag(slave)
+        eq_(restored_lflag & _CBREAK_LFLAG_MASK, original_lflag & _CBREAK_LFLAG_MASK)
+        eq_(cm._char_buffered_refcount, 0)
+    finally:
+        slave.close()
+        os.close(master_fd)

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -10,7 +10,6 @@ from nose.tools import eq_, ok_
 from fabric.state import env, output
 from fabric.context_managers import (cd, settings, lcd, hide, shell_env, quiet,
     warn_only, prefix, path, char_buffered)
-import fabric.context_managers as cm
 from fabric.operations import run, local, _prefix_commands
 from mock_streams import mock_streams
 from utils import FabricTest
@@ -399,13 +398,14 @@ def test_char_buffered_refcount_returns_to_zero():
     After all char_buffered() contexts exit, the internal refcount should be 0.
     """
     master_fd, slave = _open_pty()
+    fd = slave.fileno()
     try:
         with char_buffered(slave):
             with char_buffered(slave):
-                eq_(cm._char_buffered_refcount, 2)
-            eq_(cm._char_buffered_refcount, 1)
-        eq_(cm._char_buffered_refcount, 0)
-        ok_(cm._char_buffered_old_settings is None)
+                eq_(char_buffered._refcounts[fd], 2)
+            eq_(char_buffered._refcounts[fd], 1)
+        ok_(fd not in char_buffered._refcounts)
+        ok_(fd not in char_buffered._old_settings)
     finally:
         slave.close()
         os.close(master_fd)
@@ -425,7 +425,7 @@ def test_char_buffered_exception_still_restores():
             pass
         restored_lflag = _get_lflag(slave)
         eq_(restored_lflag & _CBREAK_LFLAG_MASK, original_lflag & _CBREAK_LFLAG_MASK)
-        eq_(cm._char_buffered_refcount, 0)
+        ok_(slave.fileno() not in char_buffered._refcounts)
     finally:
         slave.close()
         os.close(master_fd)


### PR DESCRIPTION
## Summary
- The switch from multiprocessing to threading introduced a race condition in `char_buffered()` that corrupts terminal settings (disables echo, line editing, history) after running parallel tasks
- When multiple threads call `char_buffered()` concurrently, one thread saves already-modified settings and restores them later, leaving the terminal in cbreak mode
- Fix uses a lock + refcount so terminal attrs are saved once on first thread entry and restored once on last thread exit

## Details
The symptom: after running a parallel fab task, bash loses echo/line editing (up arrow doesn't work, typed characters are invisible). zsh masks this because ZLE resets terminal settings before every prompt.

The root cause is in `char_buffered()` (`fabric/context_managers.py`), which calls `tty.setcbreak()` on stdin. With multiprocessing, each child had its own fd table so this was safe. With threading, all threads share the terminal fd, and concurrent save/modify/restore cycles race against each other.

## Test plan
- [x] Existing tests pass (`nosetests tests/test_context_managers.py`)
- [x] New tests verify single-thread restore, concurrent thread restore (barrier-synchronized), refcount tracking, and exception safety
- [x] Manual: run a parallel fab task from bash, verify terminal works normally afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)