### PR TITLE
fix(parallel): preserve live linewise output

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import socket
+import threading
 import time
 from select import select
 from collections import deque
@@ -10,6 +11,9 @@ from fabric.auth import get_password, set_password
 import fabric.network
 from fabric.network import ssh, normalize
 from fabric.exceptions import CommandTimeout
+
+
+_output_lock = threading.RLock()
 
 if win32:
     import msvcrt
@@ -52,13 +56,17 @@ class OutputLooper(object):
         self.write_buffer = deque(maxlen=len(self.prefix))
 
     def _flush(self, text):
-        self.stream.write(text)
-        # Actually only flush if not in linewise mode.
-        # When linewise is set (e.g. in parallel mode) flushing makes
-        # doubling-up of line prefixes, and other mixed output, more likely.
-        if not env.linewise:
+        with _output_lock:
+            self.stream.write(text)
+            if not self.linewise:
+                self.stream.flush()
+            self.write_buffer.extend(text)
+
+    def _flush_line(self, text):
+        with _output_lock:
+            self.stream.write(text)
             self.stream.flush()
-        self.write_buffer.extend(text)
+            self.write_buffer.extend(text)
 
     def loop(self):
         """
@@ -111,8 +119,7 @@ class OutputLooper(object):
             if bytelist == '':
                 # If linewise, ensure we flush any leftovers in the buffer.
                 if self.linewise and line:
-                    self._flush(self.prefix)
-                    self._flush("".join(line))
+                    self._flush_line(self.prefix + "".join(line))
                 break
 
             # A None capture variable implies that we're in open_shell()
@@ -142,14 +149,14 @@ class OutputLooper(object):
                         end_of_line = printable_bytes[:cr.start(0)]
                         printable_bytes = printable_bytes[cr.end(0):]
 
-                        if not initial_prefix_printed:
+                        if not initial_prefix_printed and not self.linewise:
                             self._flush(self.prefix)
 
                         if _has_newline(end_of_line):
                             end_of_line = ''
 
                         if self.linewise:
-                            self._flush("".join(line) + end_of_line + "\n")
+                            self._flush_line(self.prefix + "".join(line) + end_of_line + "\n")
                             line = []
                         else:
                             self._flush(end_of_line + "\n")

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -15,6 +15,14 @@ from fabric.exceptions import CommandTimeout
 
 _output_lock = threading.RLock()
 
+
+def locked_write(stream, text, flush=False):
+    with _output_lock:
+        stream.write(text)
+        if flush:
+            stream.flush()
+
+
 if win32:
     import msvcrt
 
@@ -56,17 +64,12 @@ class OutputLooper(object):
         self.write_buffer = deque(maxlen=len(self.prefix))
 
     def _flush(self, text):
-        with _output_lock:
-            self.stream.write(text)
-            if not self.linewise:
-                self.stream.flush()
-            self.write_buffer.extend(text)
+        locked_write(self.stream, text, flush=not self.linewise)
+        self.write_buffer.extend(text)
 
     def _flush_line(self, text):
-        with _output_lock:
-            self.stream.write(text)
-            self.stream.flush()
-            self.write_buffer.extend(text)
+        locked_write(self.stream, text, flush=True)
+        self.write_buffer.extend(text)
 
     def loop(self):
         """

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -122,7 +122,8 @@ class OutputLooper(object):
             if bytelist == '':
                 # If linewise, ensure we flush any leftovers in the buffer.
                 if self.linewise and line:
-                    self._flush_line(self.prefix + "".join(line))
+                    remaining = "".join(line)
+                    self._flush_line(self.prefix + remaining + "\n")
                 break
 
             # A None capture variable implies that we're in open_shell()
@@ -152,9 +153,6 @@ class OutputLooper(object):
                         end_of_line = printable_bytes[:cr.start(0)]
                         printable_bytes = printable_bytes[cr.end(0):]
 
-                        if not initial_prefix_printed and not self.linewise:
-                            self._flush(self.prefix)
-
                         if _has_newline(end_of_line):
                             end_of_line = ''
 
@@ -162,16 +160,17 @@ class OutputLooper(object):
                             self._flush_line(self.prefix + "".join(line) + end_of_line + "\n")
                             line = []
                         else:
-                            self._flush(end_of_line + "\n")
+                            self._flush(self.prefix + end_of_line + "\n")
                         initial_prefix_printed = False
 
                     if self.linewise:
                         line += [printable_bytes]
-                    else:
+                    elif printable_bytes:
                         if not initial_prefix_printed:
-                            self._flush(self.prefix)
+                            self._flush(self.prefix + printable_bytes)
                             initial_prefix_printed = True
-                        self._flush(printable_bytes)
+                        else:
+                            self._flush(printable_bytes)
 
                 # Now we have handled printing, handle interactivity
                 read_lines = re.split(r"(\r|\n|\r\n)", bytelist)

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -705,14 +705,15 @@ def disconnect_all():
     Used at the end of ``fab``'s main loop, and also intended for use by
     library users.
     """
+    from fabric.io import locked_write
     from fabric.state import connections, output
     # Explicitly disconnect from all servers
     for key in list(connections.keys()):
-        if output.status:
-            # Here we can't use the py3k print(x, end=" ")
-            # because 2.5 backwards compatibility
-            sys.stdout.write("Disconnecting from %s ... " % denormalize(key))
         connections[key].close()
         del connections[key]
         if output.status:
-            sys.stdout.write("done.\n")
+            locked_write(
+                sys.stdout,
+                "Disconnecting from %s ... done.\n" % denormalize(key),
+                flush=True,
+            )

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -16,7 +16,7 @@ from contextlib import closing, contextmanager
 
 from fabric.context_managers import (settings, char_buffered, hide,
     quiet as quiet_manager, warn_only as warn_only_manager)
-from fabric.io import output_loop, input_loop
+from fabric.io import locked_write, output_loop, input_loop
 from fabric.network import needs_host, ssh, ssh_config
 from fabric.sftp import SFTP
 from fabric.state import env, connections, output, win32, default_channel
@@ -832,7 +832,7 @@ def _execute(channel, command, pty=True, combine_stderr=None,
         if output.running \
             and (output.stdout and stdout_buf and not stdout_buf.endswith("\n")) \
             or (output.stderr and stderr_buf and not stderr_buf.endswith("\n")):
-            print("")
+            locked_write(sys.stdout, "\n", flush=True)
 
         return stdout_buf, stderr_buf, status
 
@@ -905,9 +905,17 @@ def _run_command(command, shell=True, pty=True, combine_stderr=True,
         # Execute info line
         which = 'sudo' if sudo else 'run'
         if output.debug:
-            print("[%s] %s: %s" % (env.host_string, which, wrapped_command))
+            locked_write(
+                sys.stdout,
+                "[%s] %s: %s\n" % (env.host_string, which, wrapped_command),
+                flush=True,
+            )
         elif output.running:
-            print("[%s] %s: %s" % (env.host_string, which, given_command))
+            locked_write(
+                sys.stdout,
+                "[%s] %s: %s\n" % (env.host_string, which, given_command),
+                flush=True,
+            )
 
         # Actual execution, stdin/stdout/stderr handling, and termination
         result_stdout, result_stderr, status = _execute(

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -5,6 +5,7 @@ import textwrap
 import threading
 
 from fabric import state
+from fabric.io import locked_write
 from fabric.utils import abort, warn, error
 from fabric.network import to_dict, disconnect_all
 from fabric.context_managers import settings
@@ -218,7 +219,11 @@ def _execute(task, host, my_env, args, kwargs, jobs, task_queue):
     """
     # Log to stdout
     if state.output.running and not hasattr(task, 'return_value'):
-        print("[%s] Executing task '%s'" % (host, my_env['command']))
+        locked_write(
+            sys.stdout,
+            "[%s] Executing task '%s'\n" % (host, my_env['command']),
+            flush=True,
+        )
     # Create per-run env with connection settings
     local_env = to_dict(host)
     local_env.update(my_env)

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -125,6 +125,7 @@ def puts(text, show_prefix=None, end="\n", flush=False):
 
     .. seealso:: `~fabric.utils.fastprint`
     """
+    from fabric.io import locked_write
     from fabric.state import output, env
     if show_prefix is None:
         show_prefix = env.output_prefix
@@ -132,9 +133,7 @@ def puts(text, show_prefix=None, end="\n", flush=False):
         prefix = ""
         if env.host_string and show_prefix:
             prefix = "[%s] " % env.host_string
-        sys.stdout.write(prefix + str(text) + end)
-        if flush:
-            sys.stdout.flush()
+        locked_write(sys.stdout, prefix + str(text) + end, flush=flush)
 
 
 def fastprint(text, show_prefix=False, end="", flush=True):

--- a/fabric/version.py
+++ b/fabric/version.py
@@ -6,8 +6,87 @@ problems with ``__init__.py`` (which is loaded by setup.py during installation,
 which in turn needs access to this version information.)
 """
 
+import os
+import re
 
-VERSION = (1, 20, 2, 'final', 0)
+
+_VERSION_RE = re.compile(
+    r'^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?'
+    r'(?:(?P<type>a|b|rc)(?P<type_num>\d*)?)?$'
+)
+_PROJECT_VERSION_RE = re.compile(
+    r'^version\s*=\s*["\'](?P<version>[^"\']+)["\']\s*$'
+)
+_VERSION_TYPE_NAMES = {
+    'a': 'alpha',
+    'b': 'beta',
+    'rc': 'release candidate',
+}
+
+
+def _project_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read_pyproject_version():
+    pyproject = os.path.join(_project_root(), 'pyproject.toml')
+    in_project = False
+
+    try:
+        with open(pyproject) as fd:
+            for raw_line in fd:
+                line = raw_line.strip()
+                if line == '[project]':
+                    in_project = True
+                    continue
+                if line.startswith('['):
+                    in_project = False
+                if in_project:
+                    match = _PROJECT_VERSION_RE.match(line)
+                    if match:
+                        return match.group('version')
+    except IOError:
+        return None
+
+    return None
+
+
+def _read_installed_version():
+    try:
+        from importlib import metadata
+    except ImportError:
+        return None
+
+    try:
+        return metadata.version('fab-classic')
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _read_project_version():
+    version = _read_pyproject_version() or _read_installed_version()
+    if version is None:
+        raise RuntimeError('Unable to determine fab-classic version')
+    return version
+
+
+def _parse_version(version):
+    match = _VERSION_RE.match(version)
+    if match is None:
+        raise ValueError('Unsupported version string: %s' % version)
+
+    type_key = match.group('type')
+    type_num = match.group('type_num')
+    return (
+        int(match.group('major')),
+        int(match.group('minor')),
+        int(match.group('patch') or 0),
+        _VERSION_TYPE_NAMES[type_key] if type_key else 'final',
+        int(type_num) if type_num else 0,
+    )
+
+
+VERSION = _parse_version(_read_project_version())
 
 
 def git_sha():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -53,3 +53,18 @@ def test_pip_progressbar_at_4096_byte_boundary_error():
     with settings(hide('everything')):
         ol.loop()
     eq_(expect, sys.stdout.getvalue())
+
+
+@mock_streams('stdout')
+def test_linewise_eof_empty_fragment_outputs_complete_line():
+    class Mock(object):
+        def __init__(self):
+            self.responses = ['1\n', '']
+
+        def recv(self, size):
+            return self.responses.pop(0)
+
+    with settings(host_string='host1', linewise=True):
+        OutputLooper(Mock(), 'recv', sys.stdout, [], None).loop()
+
+    eq_(sys.stdout.getvalue(), '[host1] out: 1\n[host1] out: \n')

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,10 +1,12 @@
+import sys
+
 from fabric.context_managers import hide, settings
 from fabric.decorators import parallel
 from fabric.operations import run
 from fabric.state import env
 from fabric.tasks import execute
 
-from utils import FabricTest, eq_, aborts
+from utils import FabricTest, eq_, aborts, assert_contains
 from mock_streams import mock_streams
 from server import server, RESPONSES, USER, HOST, PORT
 
@@ -76,6 +78,39 @@ class TestParallel(FabricTest):
                 result = execute(mytask, hosts=[host1, host2])
             eq_(result[host1], None)
             assert isinstance(result[host2], OhNoesException)
+
+    @server(port=2200, responses={
+        'host1-output': 'host1 line1\nhost1 line2',
+        'host2-failure': ['host2 line1\nhost2 line2', '', 1],
+    })
+    @server(port=2201, responses={
+        'host1-output': 'host1 line1\nhost1 line2',
+        'host2-failure': ['host2 line1\nhost2 line2', '', 1],
+    })
+    @mock_streams('both')
+    def test_parallel_output_is_not_lost_when_host_fails(self):
+        host1 = '127.0.0.1:2200'
+        host2 = '127.0.0.1:2201'
+
+        @parallel
+        def mytask():
+            if env.host_string == host1:
+                run('host1-output')
+            else:
+                run('host2-failure')
+
+        try:
+            execute(mytask, hosts=[host1, host2])
+        except SystemExit:
+            pass
+        else:
+            raise AssertionError('parallel failure did not abort')
+
+        output = sys.stdall.getvalue()
+        assert_contains(r'\[%s\] out: host1 line1' % host1, output)
+        assert_contains(r'\[%s\] out: host1 line2' % host1, output)
+        assert_contains(r'\[%s\] out: host2 line1' % host2, output)
+        assert_contains(r'\[%s\] out: host2 line2' % host2, output)
 
     @server(port=2200)
     @server(port=2201)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,18 +7,26 @@ from nose.tools import eq_
 import fabric.version
 
 
+def test_version_comes_from_pyproject():
+    eq_(fabric.version.__version__, fabric.version._read_pyproject_version())
+
+
 def test_get_version():
     get_version = fabric.version.get_version
-    for tup, short, normal, verbose in [
-        ((0, 9, 0, 'final', 0), '0.9.0', '0.9', '0.9 final'),
-        ((0, 9, 1, 'final', 0), '0.9.1', '0.9.1', '0.9.1 final'),
-        ((0, 9, 0, 'alpha', 1), '0.9a1', '0.9 alpha 1', '0.9 alpha 1'),
-        ((0, 9, 1, 'beta', 1), '0.9.1b1', '0.9.1 beta 1', '0.9.1 beta 1'),
-        ((0, 9, 0, 'release candidate', 1),
-            '0.9rc1', '0.9 release candidate 1', '0.9 release candidate 1'),
-        ((1, 0, 0, 'alpha', 0), '1.0a', '1.0 pre-alpha', '1.0 pre-alpha'),
-    ]:
-        fabric.version.VERSION = tup
-        yield eq_, get_version('short'), short
-        yield eq_, get_version('normal'), normal
-        yield eq_, get_version('verbose'), verbose
+    original = fabric.version.VERSION
+    try:
+        for tup, short, normal, verbose in [
+            ((0, 9, 0, 'final', 0), '0.9.0', '0.9', '0.9 final'),
+            ((0, 9, 1, 'final', 0), '0.9.1', '0.9.1', '0.9.1 final'),
+            ((0, 9, 0, 'alpha', 1), '0.9a1', '0.9 alpha 1', '0.9 alpha 1'),
+            ((0, 9, 1, 'beta', 1), '0.9.1b1', '0.9.1 beta 1', '0.9.1 beta 1'),
+            ((0, 9, 0, 'release candidate', 1),
+                '0.9rc1', '0.9 release candidate 1', '0.9 release candidate 1'),
+            ((1, 0, 0, 'alpha', 0), '1.0a', '1.0 pre-alpha', '1.0 pre-alpha'),
+        ]:
+            fabric.version.VERSION = tup
+            eq_(get_version('short'), short)
+            eq_(get_version('normal'), normal)
+            eq_(get_version('verbose'), verbose)
+    finally:
+        fabric.version.VERSION = original


### PR DESCRIPTION
## Summary
- Serialize linewise parallel output writes so each prefixed line is written atomically
- Flush live linewise output immediately to preserve the old multiprocessing behavior
- Add regression coverage for successful and failing parallel hosts both emitting output
- Fixes the version output in `saltfab --version` not showing the actual version because the VERSION tuple isn't updated from the pyproject.toml.

## Testing
- uv run nosetests tests/test_parallel.py
- uv run nosetests tests/test_tasks.py
- uv run flake8 fabric/io.py tests/test_parallel.py
- Manual testing with saltfab, printing 10,000 lines on 30 hosts in parallel and ensuring that all host outputs show up.


## Notes
- A broader run of tests/test_tasks.py tests/test_network.py tests/test_operations.py still hits existing deterministic sudo prompt fake-server socket errors in tests/test_network.py, reproducible with TestNetwork.test_consecutive_sudos_should_not_have_blank_line.

Fixes Expensify/Expensify#633515